### PR TITLE
Zaturi update

### DIFF
--- a/app/src/main/java/kr/ac/inha/mindscope/services/InterventionService.java
+++ b/app/src/main/java/kr/ac/inha/mindscope/services/InterventionService.java
@@ -124,9 +124,7 @@ public class InterventionService extends Service {
                 }
 
                 final Notification notification = builder.build();
-                Log.d("ZATURI", "CHECKPOINT 1");
                 if (notificationManager != null) {
-                    Log.d("ZATURI", "CHECKPOINT 2");
                     notificationManager.notify(ZATURI_NOTIFICATION_ID, notification);
                     SharedPreferences.Editor editor = prefs.edit();
                     editor.putLong("zaturiLastIntervention", System.currentTimeMillis());


### PR DESCRIPTION
- Changed the logic for detecting the end of app use: launcher로 빠져나갔을 때
- Changed the Zaturi down time when 다음에 하기 is pressed: 1 hour
- Changed the time period during which Zaturi is activated: 11am - 9pm