### PR TITLE
First intervention setting suggestion

### DIFF
--- a/app/src/main/java/kr/ac/inha/mindscope/services/InterventionService.java
+++ b/app/src/main/java/kr/ac/inha/mindscope/services/InterventionService.java
@@ -52,6 +52,7 @@ public class InterventionService extends Service {
         boolean action_do_intervention = intent.getBooleanExtra("stress_do_intervention", false);
         boolean action_diff_int = intent.getBooleanExtra("stress_diff_int", false);
         boolean action_diff_int_done = intent.getBooleanExtra("stress_diff_int_done", false);
+        boolean action_set_int = intent.getBooleanExtra("stress_set_int", false);
         int path = intent.getIntExtra("path", -1);
 
         SharedPreferences prefs = getSharedPreferences("intervention", MODE_PRIVATE);
@@ -77,6 +78,11 @@ public class InterventionService extends Service {
             Toast.makeText(getApplicationContext(),
                     getApplicationContext().getString(R.string.string_do_intervention_toast),
                     Toast.LENGTH_LONG).show();
+        } else if (action_set_int) {
+            Intent openMindscope = new Intent(getApplicationContext(), MainActivity.class);
+            openMindscope.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            openMindscope.putExtra("change_intervention", true);
+            startActivity(openMindscope);
         } else {
             Context con =  getApplicationContext();
             final NotificationManager notificationManager = (NotificationManager)

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -222,6 +222,8 @@
     <string name="do_intervention">스트레스 해소하기</string>
     <string name="diff_intervention">다른거 하기</string>
     <string name="enter_diff_int">다른 해소 방안 입력</string>
+    <string name="first_intervention">첫 스트레스 해소방안을 설정해볼까요?</string>
+    <string name="move_to_first_intervention">알림을 누르면 해소 방안 설정 화면으로 이어집니다.</string>
     <!--Zaturi end-->
 
     <string name="feature_0high">한 자리에 오래 머무른 시간이 길어요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,6 +231,8 @@
     <string name="do_intervention">Relieve stress</string>
     <string name="diff_intervention">Change intervention</string>
     <string name="enter_diff_int">Enter a new intervention</string>
+    <string name="first_intervention">Set the first stress intervention!</string>
+    <string name="move_to_first_intervention">Click to set the intervention.</string>
     <!--Zaturi end-->
 
 


### PR DESCRIPTION
* 해소방안을 한번도 설정하지 않은 상태에서 알림 시점을 찾으면 최초 1회 "첫 해소방안을 설정할까요?" 알림을 보내는 기능입니다.
* MainActiviy.java 파일 153번 줄에 TODO 남겨둔 부분에서 '마음 케어' - '스트레스 해소'으로 navigation하는 코드가 필요합니다. 알림을 눌렀을 때 스트레스 해소 및 해소방안 설정하는 페이지로 바로 이동하기 위한 부분입니다. UI navigation 코드가 복잡해서 @Hwarang-Go 화랑님께 부탁드려도 될까요?
* 알림이 원하는 양식대로 제대로 뜨는 것은 테스트했는데, Campaign 시작을 안해서 authentication이 안된다고 해서 시점에 대해서는 통합 후 추가 테스트가 필요합니다.

